### PR TITLE
Improve README.md with a few tweaks

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) 2016 Simon Prévost
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# <a href='https://github.com/simonprev/solage'><img src='https://cloud.githubusercontent.com/assets/464900/15801312/1cf60030-2a5f-11e6-8470-085779e78046.png' height='65'></a>
+# <a href="https://github.com/simonprev/solage"><img src="https://cloud.githubusercontent.com/assets/464900/15801312/1cf60030-2a5f-11e6-8470-085779e78046.png" height="65"></a>
 
 [![Travis](https://travis-ci.org/simonprev/solage.svg?style=flat-square)](https://travis-ci.org/simonprev/solage)
 
-Provides basic functionalities to implement a JSONAPI (like [jsonapi.org](http://jsonapi.org)) compliant API.
+Provides basic functionalities to implement a [JSON API](http://jsonapi.org)-compliant API.
 
 * [Installation](#installation)
 * [Why?](#why-)
@@ -15,36 +15,41 @@ Provides basic functionalities to implement a JSONAPI (like [jsonapi.org](http:/
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+Add `solage` to the `deps` function in your project’s `mix.exs` file:
 
-  1. Add solage to your list of dependencies in `mix.exs`:
+```elixir
+defp deps do
+  [
+    …,
+    {:solage, "~> 0.1"}
+  ]
+end
+```
 
-        def deps do
-          [{:solage, "~> 0.0.1"}]
-        end
+Then run `mix do deps.get, deps.compile` inside your project’s directory.
 
 ## Why?
 
-While implementing a jsonapi.org compliant API in Elixir, I stumbled upon 2 great packages: JaSerializer and jsonapi.
-With great respect to the package’s maintainers, I found 3 problems with those 2 packages:
+While implementing a JSON API-compliant API in Elixir, I stumbled upon two great packages: `JaSerializer` and `jsonapi`.
+With great respect to their maintainers, I found three problems with those packages:
 
-- Restrictive and unextensible Domain-Specific-Language.
-- URL guessing.
-- Missing query restriction, or restriction at the wrong place. _(Which relation can be included, which filters are permitted)_
+- Restrictive and unextensible Domain-Specific-Language
+- URL guessing
+- Missing query restriction, or restriction at the wrong place _(Which relation can be included, which filters are permitted)_
 
 At first I tried to contribute to the packages but I thought that it could be a good exercise to implement those things myself :P
-*A lot* of what is implement comes directly from those 2 packages. Thanks again for the cleverness of the maintainers.
+*A lot* of what is implemented comes directly from those two packages. Thanks again for the cleverness of their maintainers.
 
 ## Description
 
-This lib doesn’t implement the whole view with `id`, `type`, `attributes` or `relationships`.
-It lets your application define this stuff. A bit more boilerplate but you’ll never have to
-bend or hook you in a restrictive DSL. This means you can implement an API with nested resource and not use `included` function.
-You would benefit from awesome features such as preload parsing, sort parsing... Those concepts are good on their own without
-attaching the whole [jsonapi.org](http://jsonapi.org) standard in front of it. This is what this package is aiming for.
+This package doesn’t implement the whole view with `id`, `type`, `attributes` or `relationships`.
+It lets your application define this stuff. It’s a bit more of boilerplate code to write but you’ll never have to
+bend or hook you in a restrictive DSL. This means you can implement an API with nested resources and not use the `included` feature.
+You would benefit from awesome features such as preload parsing, sort parsing, etc. Those concepts are good on their own without
+attaching the whole JSON API specification in front of it. This is what this package is aiming for.
 
 - Don’t want to provide unecessary routes? This package won’t invent routes for your app.
-- Want to implement sparse fields on a certain view? With the `render/3`, you have all the tools to implement this kind of thing.
+- Want to implement sparse fields on a certain view? With the `render/3` function, you have all the tools to implement this kind of thing.
 - Want to embed a certain assocation on the object data? You get the point.
 
 ## Solage.QueryConfig
@@ -54,8 +59,8 @@ is rendering the view to use a config that fits your need. The config can be ini
 
 ### What’s inside QueryConfig
 
-- `include`: List all includes required by the request. With options set at the plug level, you can add `always_includes` or whitelist include with `allowed_includes`. The output is compliant to a `MyApp.Repo.preload/2` function call. Easy integration with Ecto! The include is used to build the `included` structure found in a JSON API response.
-- `sort`: List that looks like `[asc: :attribute, desc: :other_attribute]`. Like the `include`, you can specified options at the plug level to allow specific sort params.
+- `include`: List all includes required by the request. With options set at the plug level, you can add `always_includes` or whitelist includes with `allowed_includes`. The output is compliant to a `MyApp.Repo.preload/2` function call (easy integration with Ecto!). The include is used to build the `included` structure found in a JSON API response.
+- `sort`: List that looks like `[asc: :attribute, desc: :other_attribute]`. Like the `include` option, you can specify options at the plug level to allow specific sort params.
 - `filter`: Map that can be filtered like the above options.
 - `fields`: Map that contains fields that need to be in the resource data.
 
@@ -68,18 +73,18 @@ To obtain the relation view of an included resource, you will need to implement 
 
 **2 functions**
 
-- `render/4` Render the representation of a resource. It’s just a proxy for `view.render(data, query_config, conn)`
-- `included/4` With the QueryConfig, parse the data and call `data/4` on each resource. Takes all the rendered resources and put them in a list.
+- `render/4`: Render the representation of a resource. It’s just a proxy for `view.render(data, query_config, conn)`
+- `included/4`: With the QueryConfig, parse the data and call `data/4` on each resource. Takes all the rendered resources and put them in a list.
 
 ## Solage.DataTransform
 
 The `DataTransform` module provides a quick and extensible way of encoding and decoding data keys. You could use it in a plug
-before using the params to replace "-" with "\_" on all keys. Or run it on the encoded data before sending the response.
+before using the params to replace `-` with `_` on all keys. Or run it on the encoded data before sending the response.
 
 The decoder and encoder are set in the config `:solage, :decoder_formatter` and `:solage, :encoder_formatter`.
 Check the `Solage.DataTransform.Transformer` behaviour to implement your own.
 
-**Valid formatters:**
+### Valid formatters
 
 - `:dasherized` (Default)
 - `:nothing` Don’t transform the keys
@@ -98,7 +103,7 @@ end
 ## Solage.AttributeTransform
 
 The `AttributeTransform` module provides a clean and extensible way to transform a JSON API payload to a usable flat map like a regular REST API would accept.
-You can use the default resolver that assume that your relationship will be the name of the association + `_id` for *belongs\_to* and `_ids` for *has\_many*.
+You can use the default resolver that assume that your relationship will be the _name of the association_ + `_id` for `belongs_to` associations and _name of the association_ + `_ids` for `has_many` associations.
 
 But the interface could be implemented to support other kind of input. Check the `Solage.AttributeTransform.Transformer` behaviour to implement your own.
 
@@ -124,7 +129,7 @@ Solage.AttributeTransform.flatten(params)
 
 ## Examples
 
-**Views:**
+### Views
 
 ```elixir
 defmodule PostView do
@@ -150,7 +155,7 @@ defmodule UserView do
 end
 ```
 
-**Endpoint:**
+### Endpoint
 
 ```elixir
 def show(conn, _) do
@@ -171,7 +176,7 @@ def show(conn, _) do
 end
 ```
 
-**Response:**
+### Reponse
 
 ```json
 {
@@ -191,3 +196,7 @@ end
   ]
 }
 ```
+
+## License
+
+Solage is © 2016 Simon Prévost and may be freely distributed under the [MIT license](https://github.com/simonprev/solage/blob/master/LICENSE.md). See the `LICENSE.md` file for more information.

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,7 @@ defmodule JsonapiKit.Mixfile do
     [app: :solage,
      version: "0.0.1",
      elixir: "~> 1.2",
+     package: package,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      dialyzer: [plt_add_apps: [:plug]],
@@ -26,5 +27,12 @@ defmodule JsonapiKit.Mixfile do
       {:credo, "~> 0.3", only: [:dev, :test]},
       {:dialyxir, "~> 0.3.3", only: [:dev, :test]}
     ]
+  end
+
+  defp package do
+    [name: :solage,
+     maintainers: ["Simon Prévost"],
+     licenses: ["MIT"],
+     links: %{"GitHub" => "https://github.com/simonprev/solage"}]
   end
 end


### PR DESCRIPTION
Usually I try to format Markdown files with a maximum line length. However, since I wanted to fix a few typos and syntax tweaks, I didn’t make changes to the line lengths to make the _diff_ easier to parse 😄 

When you’re satisfied with the content, I’ll make changes to the file formatting style.
