### PR TITLE
Update README with correct package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `solage` to the `deps` function in your project’s `mix.exs` file:
 defp deps do
   [
     …,
-    {:solage, "~> 0.1"}
+    {:solage, "~> 0.0.1"}
   ]
 end
 ```


### PR DESCRIPTION
I've tried to use this package yesterday and I couldn't install it by following the `README.md`.

```
** (Mix) No package version in registry matches solage ~> 0.1 (from: mix.exs)
```

The real version number is `0.0.1` and not `0.1` :)
