### PR TITLE
Update README.md with correct version package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `solage` to the `deps` function in your project’s `mix.exs` file:
 defp deps do
   [
     …,
-    {:solage, "~> 0.1"}
+    {:solage, "> 0.0.0"}
   ]
 end
 ```


### PR DESCRIPTION
As discussed in PR #3, we change the hardcoded version number with `< 0.0.0` to install the latest version and lock it.
